### PR TITLE
fix: use correct field for newcomer resolve rate sorting

### DIFF
--- a/gfibot/backend/routes/repos.py
+++ b/gfibot/backend/routes/repos.py
@@ -97,7 +97,7 @@ def get_paged_repo_detail(
         elif filter == RepoSort.ISSUE_CLOSE_TIME:
             q = q.order_by("issue_close_time")
         elif filter == RepoSort.NEWCOMER_RESOLVE_RATE:
-            q = q.order_by("-r_newcomer_resolve")
+            q = q.order_by("-r_newcomer_resolved")
         elif filter == RepoSort.STARS:
             q = q.order_by("-n_stars")
         else:

--- a/gfibot/backend/routes/repos.py
+++ b/gfibot/backend/routes/repos.py
@@ -170,7 +170,7 @@ def get_paged_repo_brief(
         elif filter == RepoSort.ISSUE_CLOSE_TIME:
             q = q.order_by("issue_close_time")
         elif filter == RepoSort.NEWCOMER_RESOLVE_RATE:
-            q = q.order_by("-r_newcomer_resolve")
+            q = q.order_by("-r_newcomer_resolved")
         elif filter == RepoSort.STARS:
             q = q.order_by("-n_stars")
         else:

--- a/gfibot/backend/routes/user.py
+++ b/gfibot/backend/routes/user.py
@@ -64,7 +64,7 @@ def get_user_queries(user: str, filter: Optional[RepoSort] = None):
         elif filter == RepoSort.ISSUE_CLOSE_TIME:
             q = q.order_by("-issue_close_time")
         elif filter == RepoSort.NEWCOMER_RESOLVE_RATE:
-            q = q.order_by("-r_newcomer_resolve")
+            q = q.order_by("-r_newcomer_resolved")
         elif filter == RepoSort.STARS:
             q = q.order_by("-n_stars")
         else:


### PR DESCRIPTION
## Summary

This PR fixes incorrect field names used when sorting repositories by newcomer resolve rate.

## Changes
- Replaced `r_newcomer_resolve` with `r_newcomer_resolved` in:
  - `gfibot/backend/routes/repos.py` (2 occurrences)
  - `gfibot/backend/routes/user.py` (1 occurrence)

The field `r_newcomer_resolved` is defined in `gfibot/collections/model.py`, while the previous queries referenced a non-existent field.